### PR TITLE
fix: handle invalid cookie encoding

### DIFF
--- a/src/lib/cookies.test.ts
+++ b/src/lib/cookies.test.ts
@@ -22,6 +22,11 @@ describe('cookies', () => {
     expect(getSid(headers)).toBe('xyz-789');
   });
 
+  it('getSid: 不正なエンコードでも落ちずにそのまま返す', () => {
+    const headers = new Headers({ Cookie: 'sid=%E0%A4%A' });
+    expect(getSid(headers)).toBe('%E0%A4%A');
+  });
+
   it('getSid: sidが無い場合はundefined', () => {
     const headers = new Headers({ Cookie: 'foo=1; bar=2' });
     expect(getSid(headers)).toBeUndefined();

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -30,7 +30,14 @@ function parseCookieHeader(header: string | null | undefined): Record<string, st
     if (idx <= 0) continue;
     const name = pair.slice(0, idx).trim();
     const val = pair.slice(idx + 1).trim();
-    out[name] = decodeURIComponent(val);
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(val);
+    } catch {
+      // 変なパーセントエンコードがあっても落ちないようにそのまま使う
+      decoded = val;
+    }
+    out[name] = decoded;
   }
   return out;
 }


### PR DESCRIPTION
## Summary
- avoid crashing on malformed cookie values
- add regression test for invalid cookie encoding

## Testing
- `pnpm test` *(fails: 35 failed | 41 passed)*
- `pnpm test src/lib/cookies.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1f9e75f84832995f1c75c38c8142e