### PR TITLE
fix: broaden image detection and refactor sanitizer

### DIFF
--- a/src/lib/log.test.ts
+++ b/src/lib/log.test.ts
@@ -35,6 +35,11 @@ describe('log: sanitizeGenerateInput', () => {
     expect(s.motion).toBe('neutral');
     expect(s.microPan).toBe(true);
   });
+
+  it('JPEG画像でもhasImageがtrueになる', () => {
+    const s = sanitizeGenerateInput({ image: 'data:image/jpeg;base64,abc' });
+    expect(s.hasImage).toBe(true);
+  });
 });
 
 describe('log: logEvent', () => {

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -16,30 +16,39 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 
 export function sanitizeGenerateInput(body: unknown): SafeGenerateLog {
   const r = isRecord(body) ? body : {};
-  const image = typeof r.image === 'string' ? r.image : '';
-  const script = typeof r.script === 'string' ? r.script : '';
+
+  /**
+   * 値が文字列ならそのまま返し、そうでなければ undefined。
+   * 呼び出し側でデフォルト値を与える想定。
+   */
+  function getString(v: unknown): string | undefined {
+    return typeof v === 'string' ? v : undefined;
+  }
+
+  /**
+   * 値が真偽値ならそのまま返し、そうでなければ undefined。
+   */
+  function getBoolean(v: unknown): boolean | undefined {
+    return typeof v === 'boolean' ? v : undefined;
+  }
+
+  const image = getString(r.image);
+  const script = getString(r.script) ?? '';
   const voiceR = isRecord(r.voice) ? r.voice : undefined;
-  const hasImage = /^data:image\/png;base64,/i.test(image);
-  const lengthSec = r.lengthSec === 8 || r.lengthSec === 16 ? (r.lengthSec as 8 | 16) : undefined;
-  const consent = typeof r.consent === 'boolean' ? r.consent : undefined;
-  const motion = typeof r.motion === 'string' ? r.motion : undefined;
-  const microPan = typeof r.microPan === 'boolean' ? r.microPan : undefined;
+  const hasImage =
+    typeof image === 'string' && /^data:image\/(?:png|jpe?g|webp);base64,/i.test(image);
+  const lengthSec = r.lengthSec === 8 || r.lengthSec === 16 ? r.lengthSec : undefined;
+  const consent = getBoolean(r.consent);
+  const motion = getString(r.motion);
+  const microPan = getBoolean(r.microPan);
   const voice = voiceR
     ? {
-        gender: typeof voiceR.gender === 'string' ? voiceR.gender : undefined,
-        tone: typeof voiceR.tone === 'string' ? voiceR.tone : undefined,
+        gender: getString(voiceR.gender),
+        tone: getString(voiceR.tone),
       }
     : undefined;
 
-  return {
-    hasImage,
-    scriptChars: script.length,
-    lengthSec,
-    consent,
-    voice,
-    motion,
-    microPan,
-  };
+  return { hasImage, scriptChars: script.length, lengthSec, consent, voice, motion, microPan };
 }
 
 type LogType =


### PR DESCRIPTION
## Summary
- broaden `sanitizeGenerateInput` image detection to handle JPEG/WEBP
- refactor sanitize logic with helpers for strings and booleans
- test JPEG image handling

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: 35 failed, 41 passed)*
- `pnpm test src/lib/log.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1f9e75f84832995f1c75c38c8142e